### PR TITLE
Add user management pages

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -139,14 +139,14 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                         {subMenuUsuarios && (
                             <div className="ml-6 mt-1 space-y-1 text-sm text-blue-700">
                                 <button
-                                    onClick={() => router.push('/dashboard/usuario-empresa/registrar-usuario-empresa')}
-                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuario-empresa/registrar-usuario-empresa' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
+                                    onClick={() => router.push('/dashboard/usuarios/registrar')}
+                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuarios/registrar' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
                                 >
                                     Registrar Usuario
                                 </button>
                                 <button
-                                    onClick={() => router.push('/dashboard/usuario-empresa')}
-                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuario-empresa' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
+                                    onClick={() => router.push('/dashboard/usuarios')}
+                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuarios' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
                                 >
                                     Consultar Usuarios
                                 </button>
@@ -156,13 +156,17 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 </aside>
 
                 <main className="flex-1 overflow-y-auto p-4">
-                    {vistaActiva === 'registrarEmpresa' && <RegistrarEmpresa />}
-                    {vistaActiva === 'listarEmpresas' && <ListaEmpresas />}
-                    {vistaActiva === 'inicio' && (
-                        <div className="space-y-4">
-                            <h1 className="text-2xl font-bold">Dashboard General</h1>
-                            <p className="text-gray-600">Aquí irá la visualización de estadísticas, accesos rápidos y módulos.</p>
-                        </div>
+                    {children ?? (
+                        <>
+                            {vistaActiva === 'registrarEmpresa' && <RegistrarEmpresa />}
+                            {vistaActiva === 'listarEmpresas' && <ListaEmpresas />}
+                            {vistaActiva === 'inicio' && (
+                                <div className="space-y-4">
+                                    <h1 className="text-2xl font-bold">Dashboard General</h1>
+                                    <p className="text-gray-600">Aquí irá la visualización de estadísticas, accesos rápidos y módulos.</p>
+                                </div>
+                            )}
+                        </>
                     )}
                 </main>
 

--- a/src/app/dashboard/usuarios/ConsultarUsuarios.tsx
+++ b/src/app/dashboard/usuarios/ConsultarUsuarios.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { Pencil, Trash2 } from 'lucide-react';
+import ModalEditarUsuario from '@/components/usuarios/ModalEditarUsuario';
+
+export default function ConsultarUsuarios() {
+  const [usuarios, setUsuarios] = useState<any[]>([]);
+  const [filtro, setFiltro] = useState('');
+  const [usuarioEditando, setUsuarioEditando] = useState<any | null>(null);
+
+  useEffect(() => {
+    fetchUsuarios();
+  }, []);
+
+  const fetchUsuarios = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+      });
+      const data = await res.json();
+      setUsuarios(data);
+    } catch {
+      toast.error('Error al cargar usuarios');
+    }
+  };
+
+  const eliminarUsuario = async (id: string) => {
+    if (!confirm('¿Eliminar este usuario?')) return;
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Usuario eliminado');
+      fetchUsuarios();
+    } catch {
+      toast.error('Error al eliminar usuario');
+    }
+  };
+
+  const usuariosFiltrados = usuarios.filter((u) =>
+    u.nombres.toLowerCase().includes(filtro.toLowerCase()) ||
+    u.apellidos.toLowerCase().includes(filtro.toLowerCase()) ||
+    u.documento.includes(filtro)
+  );
+
+  return (
+    <div className="p-6 bg-[#fdfdfc] rounded-xl shadow-sm">
+      <h2 className="text-2xl font-semibold mb-4 text-black">Usuarios</h2>
+
+      <div className="mb-4">
+        <Input
+          placeholder="Buscar usuario por nombre, documento o apellido"
+          className="md:w-96 placeholder:text-gray-400 text-black"
+          value={filtro}
+          onChange={(e) => setFiltro(e.target.value)}
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-lg">
+        <table className="min-w-full text-sm text-black">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="px-4 py-2 text-left">Documento</th>
+              <th className="px-4 py-2 text-left">Nombre Completo</th>
+              <th className="px-4 py-2 text-left">Teléfono</th>
+              <th className="px-4 py-2 text-left">Email</th>
+              <th className="px-4 py-2 text-left">Rol</th>
+              <th className="px-4 py-2 text-left">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usuariosFiltrados.map((u) => (
+              <tr key={u.id} className="hover:bg-gray-50 group transition">
+                <td className="px-4 py-2">{u.documento}</td>
+                <td className="px-4 py-2">{u.nombres} {u.apellidos}</td>
+                <td className="px-4 py-2">{u.telefono}</td>
+                <td className="px-4 py-2">{u.email}</td>
+                <td className="px-4 py-2">{u.rol}</td>
+                <td className="px-4 py-2 opacity-0 group-hover:opacity-100 transition space-x-2">
+                  <Button variant="outline" size="sm" onClick={() => setUsuarioEditando(u)}>
+                    <Pencil className="w-4 h-4" />
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={() => eliminarUsuario(u.id)}>
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {usuariosFiltrados.length === 0 && (
+              <tr>
+                <td colSpan={6} className="text-center py-4">No hay usuarios registrados.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {usuarioEditando && (
+        <ModalEditarUsuario
+          usuario={usuarioEditando}
+          onClose={() => setUsuarioEditando(null)}
+          onActualizado={fetchUsuarios}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/usuarios/RegistrarUsuario.tsx
+++ b/src/app/dashboard/usuarios/RegistrarUsuario.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+
+export default function RegistrarUsuario() {
+  const [formData, setFormData] = useState({
+    documento: '',
+    nombres: '',
+    apellidos: '',
+    telefono: '',
+    email: '',
+    rol: '',
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json();
+      if (!res.ok || !data?.id) {
+        throw new Error();
+      }
+      toast.success('Usuario registrado exitosamente');
+    } catch {
+      toast.error('Error al registrar usuario');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-[#fdfdfc] rounded-xl shadow-sm max-w-3xl mx-auto">
+      <h2 className="text-2xl font-semibold mb-4 text-black">Registrar Usuario</h2>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[
+            ['documento', 'Documento'],
+            ['nombres', 'Nombres'],
+            ['apellidos', 'Apellidos'],
+            ['telefono', 'Teléfono'],
+            ['email', 'Correo'],
+            ['rol', 'Rol'],
+          ].map(([name, label]) => (
+            <div key={name}>
+              <Label htmlFor={name} className="text-black">
+                {label}
+              </Label>
+              <Input
+                name={name}
+                value={formData[name]}
+                onChange={handleChange}
+                placeholder={label}
+                className="text-black placeholder-gray-400"
+              />
+            </div>
+          ))}
+        </div>
+        <div className="text-right">
+          <Button type="submit" disabled={loading} className="bg-blue-700 hover:bg-blue-800 text-white rounded-xl">
+            {loading ? 'Registrando...' : 'Registrar'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -1,0 +1,5 @@
+import ConsultarUsuarios from './ConsultarUsuarios';
+
+export default function UsuariosPage() {
+  return <ConsultarUsuarios />;
+}

--- a/src/app/dashboard/usuarios/registrar/page.tsx
+++ b/src/app/dashboard/usuarios/registrar/page.tsx
@@ -1,0 +1,5 @@
+import RegistrarUsuario from '../RegistrarUsuario';
+
+export default function RegistrarUsuarioPage() {
+  return <RegistrarUsuario />;
+}

--- a/src/components/usuarios/ModalEditarUsuario.tsx
+++ b/src/components/usuarios/ModalEditarUsuario.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import UsuarioForm from './UsuarioForm';
+import { toast } from 'sonner';
+
+interface Props {
+  usuario: any;
+  onClose: () => void;
+  onActualizado: () => void;
+}
+
+export default function ModalEditarUsuario({ usuario, onClose, onActualizado }: Props) {
+  const [formData, setFormData] = useState({ ...usuario });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleUpdate = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios/${usuario.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Usuario actualizado');
+      onActualizado();
+      onClose();
+    } catch {
+      toast.error('Error al actualizar usuario');
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="backdrop-blur-xl">
+        <DialogHeader>
+          <DialogTitle className="text-black">Editar Usuario</DialogTitle>
+        </DialogHeader>
+        <UsuarioForm formData={formData} onChange={handleChange} />
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={onClose}>Cancelar</Button>
+          <Button onClick={handleUpdate} className="bg-blue-600 text-white hover:bg-blue-700">Guardar</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/usuarios/UsuarioForm.tsx
+++ b/src/components/usuarios/UsuarioForm.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+  formData: any;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function UsuarioForm({ formData, onChange }: Props) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {[
+        ['documento', 'Documento'],
+        ['nombres', 'Nombres'],
+        ['apellidos', 'Apellidos'],
+        ['telefono', 'Teléfono'],
+        ['email', 'Correo'],
+        ['rol', 'Rol'],
+      ].map(([name, label]) => (
+        <div key={name}>
+          <Label htmlFor={name} className="text-black">
+            {label}
+          </Label>
+          <Input
+            name={name}
+            id={name}
+            placeholder={label}
+            value={formData[name]}
+            onChange={onChange}
+            className="text-black placeholder:text-gray-400 rounded-xl"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `RegistrarUsuario` and `ConsultarUsuarios`
- add reusable `UsuarioForm` and `ModalEditarUsuario`
- update Dashboard layout to link to user pages
- wire up Next.js pages for user routes
- render nested user pages in dashboard layout

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851e14753b483209b70a6141f64852c