### PR TITLE
Add user management pages

### DIFF
--- a/src/app/components/ModalEditarUsuarioEmpresa.tsx
+++ b/src/app/components/ModalEditarUsuarioEmpresa.tsx
@@ -5,12 +5,13 @@ import { UsuarioEmpresaForm } from './UsuarioEmpresaForm';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
+import type { Usuario, Empresa } from '@/types';
 
 interface Props {
-  usuario: any;
+  usuario: Usuario;
   onClose: () => void;
   onActualizado: () => void;
-  empresas: { id: string; razonSocial: string }[];
+  empresas: Empresa[];
 }
 
 export default function ModalEditarUsuarioEmpresa({ usuario, onClose, onActualizado, empresas }: Props) {
@@ -55,7 +56,6 @@ export default function ModalEditarUsuarioEmpresa({ usuario, onClose, onActualiz
           onChange={handleChange}
           empresas={empresas}
           onEmpresaSelect={handleEmpresaSelect}
-          isEdit
         />
         <div className="flex justify-end gap-2 mt-4">
           <Button variant="outline" onClick={onClose}>Cancelar</Button>

--- a/src/app/components/UsuarioEmpresaForm.tsx
+++ b/src/app/components/UsuarioEmpresaForm.tsx
@@ -3,16 +3,16 @@
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Usuario, Empresa } from '@/types';
 
 interface Props {
-  formData: any;
+  formData: Usuario;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  empresas: { id: string; razonSocial: string }[];
+  empresas: Empresa[];
   onEmpresaSelect: (empresaId: string) => void;
-  isEdit?: boolean;
 }
 
-export function UsuarioEmpresaForm({ formData, onChange, empresas, onEmpresaSelect, isEdit = false }: Props) {
+export function UsuarioEmpresaForm({ formData, onChange, empresas, onEmpresaSelect }: Props) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
@@ -31,14 +31,16 @@ export function UsuarioEmpresaForm({ formData, onChange, empresas, onEmpresaSele
         </Select>
       </div>
 
-      {[
-        ['documento', 'Documento'],
-        ['nombres', 'Nombres'],
-        ['apellidos', 'Apellidos'],
-        ['telefono', 'Teléfono'],
-        ['email', 'Email'],
-        ['rol', 'Rol (admin o empleado)'],
-      ].map(([name, label]) => (
+      {(
+        [
+          ['documento', 'Documento'],
+          ['nombres', 'Nombres'],
+          ['apellidos', 'Apellidos'],
+          ['telefono', 'Teléfono'],
+          ['email', 'Email'],
+          ['rol', 'Rol (admin o empleado)'],
+        ] as [keyof Usuario, string][]
+      ).map(([name, label]) => (
         <div key={name}>
           <Label htmlFor={name} className="text-black">{label}</Label>
           <Input

--- a/src/app/dashboard/componentes/EditarEmpresaModal.tsx
+++ b/src/app/dashboard/componentes/EditarEmpresaModal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import type { Empresa } from '@/types';
 
 interface Props {
-  empresa: any;
+  empresa: Empresa;
   onClose: () => void;
   onUpdate: () => void;
 }
@@ -43,7 +44,9 @@ export default function EditarEmpresaModal({ empresa, onClose, onUpdate }: Props
       <div className="bg-white p-6 rounded shadow w-full max-w-md">
         <h3 className="text-lg font-bold mb-4 text-black">Editar Empresa</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
-          {['nit', 'razonSocial', 'direccion', 'telefono'].map((field) => (
+          {(
+            ['nit', 'razonSocial', 'direccion', 'telefono'] as (keyof Empresa)[]
+          ).map((field) => (
             <div key={field}>
               <label className="block text-sm text-gray-800 capitalize">{field}</label>
               <input

--- a/src/app/dashboard/componentes/ListaEmpresas.tsx
+++ b/src/app/dashboard/componentes/ListaEmpresas.tsx
@@ -121,7 +121,11 @@ export default function ListaEmpresas() {
       </div>
 
       {empresaEditando && (
-        <EditarEmpresaModal empresa={empresaEditando} onClose={() => setEmpresaEditando(null)} recargar={cargarEmpresas} />
+        <EditarEmpresaModal
+          empresa={empresaEditando}
+          onClose={() => setEmpresaEditando(null)}
+          onUpdate={cargarEmpresas}
+        />
       )}
     </div>
   );

--- a/src/app/dashboard/componentes/RegistrarEmpresa.tsx
+++ b/src/app/dashboard/componentes/RegistrarEmpresa.tsx
@@ -21,7 +21,6 @@ export default function RegistrarEmpresa() {
     e.preventDefault();
     setLoading(true);
     const token = localStorage.getItem('token');
-    console.log(token)
     try {
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/empresas`, {
         method: 'POST',

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,8 +10,14 @@ import ListaEmpresas from './componentes/ListaEmpresas';
 
 
 
+interface DecodedToken {
+    nombre?: string;
+    empresaNombre?: string;
+    rol?: string;
+}
+
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-    const [usuario, setUsuario] = useState<any>(null);
+    const [usuario, setUsuario] = useState<DecodedToken | null>(null);
     const [subMenuEmpresas, setSubMenuEmpresas] = useState(false);
     const [subMenuUsuarios, setSubMenuUsuarios] = useState(false);
     const [vistaActiva, setVistaActiva] = useState<'inicio' | 'registrarEmpresa' | 'listarEmpresas'>('inicio');
@@ -30,7 +36,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         }
 
         try {
-            const decoded = jwtDecode(token);
+            const decoded = jwtDecode<DecodedToken>(token);
             setUsuario(decoded);
         } catch {
             toast.error('Token inválido. Redirigiendo...');
@@ -54,13 +60,40 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         router.push('/login');
     };
 
+    const mostrarRutasUsuarios = pathname.startsWith('/dashboard/usuarios') || pathname.startsWith('/dashboard/usuario-empresa');
+
+    useEffect(() => {
+        if (pathname.startsWith('/dashboard/usuarios') || pathname.startsWith('/dashboard/usuario-empresa')) {
+            setSubMenuUsuarios(true);
+            setSubMenuEmpresas(false);
+        } else if (pathname.startsWith('/dashboard')) {
+            // If navigating to company section
+            if (vistaActiva !== 'inicio') setSubMenuEmpresas(true);
+        }
+    }, [pathname, vistaActiva]);
+
+    const toggleEmpresas = () => {
+        setSubMenuEmpresas((prev) => !prev);
+        if (!subMenuEmpresas) setSubMenuUsuarios(false);
+    };
+
+    const toggleUsuarios = () => {
+        setSubMenuUsuarios((prev) => !prev);
+        if (!subMenuUsuarios) setSubMenuEmpresas(false);
+    };
+
     return (
         <div className="h-screen flex flex-col">
             {/* Header */}
             <header className="bg-white px-6 py-4 flex justify-between items-center shadow text-blue-800">
                 <div
                     className="font-bold text-xl cursor-pointer"
-                    onClick={() => router.push('/dashboard')}
+                    onClick={() => {
+                        setVistaActiva('inicio');
+                        setSubMenuEmpresas(false);
+                        setSubMenuUsuarios(false);
+                        router.push('/dashboard');
+                    }}
                 >
                     Auren+ {usuario?.empresaNombre && `| ${usuario.empresaNombre}`}
                 </div>
@@ -91,7 +124,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                     {/* Empresas */}
                     <div>
                         <button
-                            onClick={() => setSubMenuEmpresas(!subMenuEmpresas)}
+                            onClick={toggleEmpresas}
                             className="w-full flex items-center justify-between text-blue-800 font-medium px-3 py-2 hover:bg-blue-100 rounded"
                         >
                             <span className="flex items-center gap-2">
@@ -103,7 +136,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                         {subMenuEmpresas && (
                             <div className="ml-6 mt-1 space-y-1 text-sm text-blue-700">
                                 <button
-                                    onClick={() => setVistaActiva('registrarEmpresa')}
+                                    onClick={() => {
+                                        setVistaActiva('registrarEmpresa');
+                                        setSubMenuUsuarios(false);
+                                    }}
                                     className={`block w-full text-left px-2 py-1 rounded ${vistaActiva === 'registrarEmpresa' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'
                                         }`}
                                 >
@@ -111,7 +147,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                                 </button>
 
                                 <button
-                                    onClick={() => setVistaActiva('listarEmpresas')}
+                                    onClick={() => {
+                                        setVistaActiva('listarEmpresas');
+                                        setSubMenuUsuarios(false);
+                                    }}
                                     className={`block w-full text-left px-2 py-1 rounded ${vistaActiva === 'listarEmpresas'
                                         ? 'bg-blue-100 font-semibold'
                                         : 'hover:bg-blue-50'
@@ -127,7 +166,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                     {/* Usuarios */}
                     <div>
                         <button
-                            onClick={() => setSubMenuUsuarios(!subMenuUsuarios)}
+                            onClick={toggleUsuarios}
                             className="w-full flex items-center justify-between text-blue-800 font-medium px-3 py-2 hover:bg-blue-100 rounded"
                         >
                             <span className="flex items-center gap-2">
@@ -139,14 +178,20 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                         {subMenuUsuarios && (
                             <div className="ml-6 mt-1 space-y-1 text-sm text-blue-700">
                                 <button
-                                    onClick={() => router.push('/dashboard/usuario-empresa/registrar-usuario-empresa')}
-                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuario-empresa/registrar-usuario-empresa' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
+                                    onClick={() => {
+                                        setVistaActiva('inicio');
+                                        router.push('/dashboard/usuarios/registrar');
+                                    }}
+                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuarios/registrar' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
                                 >
                                     Registrar Usuario
                                 </button>
                                 <button
-                                    onClick={() => router.push('/dashboard/usuario-empresa')}
-                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuario-empresa' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
+                                    onClick={() => {
+                                        setVistaActiva('inicio');
+                                        router.push('/dashboard/usuarios');
+                                    }}
+                                    className={`block w-full text-left px-2 py-1 rounded ${pathname === '/dashboard/usuarios' ? 'bg-blue-100 font-semibold' : 'hover:bg-blue-50'}`}
                                 >
                                     Consultar Usuarios
                                 </button>
@@ -156,13 +201,19 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 </aside>
 
                 <main className="flex-1 overflow-y-auto p-4">
-                    {vistaActiva === 'registrarEmpresa' && <RegistrarEmpresa />}
-                    {vistaActiva === 'listarEmpresas' && <ListaEmpresas />}
-                    {vistaActiva === 'inicio' && (
-                        <div className="space-y-4">
-                            <h1 className="text-2xl font-bold">Dashboard General</h1>
-                            <p className="text-gray-600">Aquí irá la visualización de estadísticas, accesos rápidos y módulos.</p>
-                        </div>
+                    {mostrarRutasUsuarios ? (
+                        children
+                    ) : (
+                        <>
+                            {vistaActiva === 'registrarEmpresa' && <RegistrarEmpresa />}
+                            {vistaActiva === 'listarEmpresas' && <ListaEmpresas />}
+                            {vistaActiva === 'inicio' && (
+                                <div className="space-y-4">
+                                    <h1 className="text-2xl font-bold">Dashboard General</h1>
+                                    <p className="text-gray-600">Aquí irá la visualización de estadísticas, accesos rápidos y módulos.</p>
+                                </div>
+                            )}
+                        </>
                     )}
                 </main>
 

--- a/src/app/dashboard/usuario-empresa/ConsultarUsuariosEmpresa.tsx
+++ b/src/app/dashboard/usuario-empresa/ConsultarUsuariosEmpresa.tsx
@@ -1,27 +1,39 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { Pencil, Trash2 } from 'lucide-react';
 import ModalEditarUsuarioEmpresa from '../../components/ModalEditarUsuarioEmpresa';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import type { Usuario, Empresa } from '@/types';
 
 export default function ConsultarUsuariosEmpresa() {
-  const [usuarios, setUsuarios] = useState<any[]>([]);
-  const [empresas, setEmpresas] = useState<any[]>([]);
+  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
+  const [empresas, setEmpresas] = useState<Empresa[]>([]);
   const [empresaSeleccionada, setEmpresaSeleccionada] = useState<string>('');
   const [filtro, setFiltro] = useState('');
-  const [usuarioEditando, setUsuarioEditando] = useState<any | null>(null);
+  const [usuarioEditando, setUsuarioEditando] = useState<Usuario | null>(null);
 
   useEffect(() => {
     fetchEmpresas();
   }, []);
 
+  const fetchUsuarios = useCallback(async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuario-empresa/empresa/${empresaSeleccionada}`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+      });
+      const data = await res.json();
+      setUsuarios(data);
+    } catch {
+      toast.error('Error al cargar usuarios');
+    }
+  }, [empresaSeleccionada]);
   useEffect(() => {
     if (empresaSeleccionada) fetchUsuarios();
-  }, [empresaSeleccionada]);
+  }, [empresaSeleccionada, fetchUsuarios]);
 
   const fetchEmpresas = async () => {
     try {
@@ -35,17 +47,6 @@ export default function ConsultarUsuariosEmpresa() {
     }
   };
 
-  const fetchUsuarios = async () => {
-    try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuario-empresa/empresa/${empresaSeleccionada}`, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-      });
-      const data = await res.json();
-      setUsuarios(data);
-    } catch {
-      toast.error('Error al cargar usuarios');
-    }
-  };
 
   const eliminarUsuario = async (id: string) => {
     if (!confirm('¿Eliminar este usuario?')) return;
@@ -78,7 +79,7 @@ export default function ConsultarUsuariosEmpresa() {
             <SelectValue placeholder="Seleccionar empresa" />
           </SelectTrigger>
           <SelectContent>
-            {empresas.map((e: any) => (
+            {empresas.map((e) => (
               <SelectItem key={e.id} value={e.id}>
                 {e.razonSocial}
               </SelectItem>
@@ -118,7 +119,11 @@ export default function ConsultarUsuariosEmpresa() {
                   <Button variant="outline" size="sm" onClick={() => setUsuarioEditando(u)}>
                     <Pencil className="w-4 h-4" />
                   </Button>
-                  <Button variant="destructive" size="sm" onClick={() => eliminarUsuario(u.id)}>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => u.id && eliminarUsuario(u.id)}
+                  >
                     <Trash2 className="w-4 h-4" />
                   </Button>
                 </td>

--- a/src/app/dashboard/usuario-empresa/RegistrarUsuarioEmpresa.tsx
+++ b/src/app/dashboard/usuario-empresa/RegistrarUsuarioEmpresa.tsx
@@ -63,7 +63,7 @@ export default function RegistrarUsuarioEmpresa() {
       }
 
       toast.success('Usuario registrado exitosamente');
-    } catch (err) {
+    } catch {
       toast.error('Error al registrar usuario');
     } finally {
       setLoading(false);

--- a/src/app/dashboard/usuarios/ConsultarUsuarios.tsx
+++ b/src/app/dashboard/usuarios/ConsultarUsuarios.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Usuario } from '@/types';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { Pencil, Trash2 } from 'lucide-react';
+import ModalEditarUsuario from '@/components/usuarios/ModalEditarUsuario';
+
+export default function ConsultarUsuarios() {
+  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
+  const [filtro, setFiltro] = useState('');
+  const [usuarioEditando, setUsuarioEditando] = useState<Usuario | null>(null);
+
+  useEffect(() => {
+    fetchUsuarios();
+  }, []);
+
+  const fetchUsuarios = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+      });
+      const data = await res.json();
+      const lista = Array.isArray(data)
+        ? (data as Usuario[])
+        : Array.isArray((data as { usuarios?: unknown }).usuarios)
+        ? ((data as { usuarios: Usuario[] }).usuarios)
+        : [];
+      setUsuarios(lista);
+    } catch {
+      toast.error('Error al cargar usuarios');
+    }
+  };
+
+  const eliminarUsuario = async (id: string) => {
+    if (!confirm('¿Eliminar este usuario?')) return;
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Usuario eliminado');
+      fetchUsuarios();
+    } catch {
+      toast.error('Error al eliminar usuario');
+    }
+  };
+
+  const usuariosFiltrados = usuarios.filter((u) =>
+    u.nombres.toLowerCase().includes(filtro.toLowerCase()) ||
+    u.apellidos.toLowerCase().includes(filtro.toLowerCase()) ||
+    u.documento.includes(filtro)
+  );
+
+  return (
+    <div className="p-6 bg-[#fdfdfc] rounded-xl shadow-sm">
+      <h2 className="text-2xl font-semibold mb-4 text-black">Usuarios</h2>
+
+      <div className="mb-4">
+        <Input
+          placeholder="Buscar usuario por nombre, documento o apellido"
+          className="md:w-96 placeholder:text-gray-400 text-black"
+          value={filtro}
+          onChange={(e) => setFiltro(e.target.value)}
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-lg">
+        <table className="min-w-full text-sm text-black">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="px-4 py-2 text-left">Documento</th>
+              <th className="px-4 py-2 text-left">Nombre Completo</th>
+              <th className="px-4 py-2 text-left">Teléfono</th>
+              <th className="px-4 py-2 text-left">Email</th>
+              <th className="px-4 py-2 text-left">Rol</th>
+              <th className="px-4 py-2 text-left">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usuariosFiltrados.map((u) => (
+              <tr key={u.id} className="hover:bg-gray-50 group transition">
+                <td className="px-4 py-2">{u.documento}</td>
+                <td className="px-4 py-2">{u.nombres} {u.apellidos}</td>
+                <td className="px-4 py-2">{u.telefono}</td>
+                <td className="px-4 py-2">{u.email}</td>
+                <td className="px-4 py-2">{u.rol}</td>
+                <td className="px-4 py-2 opacity-0 group-hover:opacity-100 transition space-x-2">
+                  <Button variant="outline" size="sm" onClick={() => setUsuarioEditando(u)}>
+                    <Pencil className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => u.id && eliminarUsuario(u.id)}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {usuariosFiltrados.length === 0 && (
+              <tr>
+                <td colSpan={6} className="text-center py-4">No hay usuarios registrados.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {usuarioEditando && (
+        <ModalEditarUsuario
+          usuario={usuarioEditando}
+          onClose={() => setUsuarioEditando(null)}
+          onActualizado={fetchUsuarios}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/usuarios/RegistrarUsuario.tsx
+++ b/src/app/dashboard/usuarios/RegistrarUsuario.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { jwtDecode } from 'jwt-decode';
+import type { Usuario, Empresa } from '@/types';
+import { toast } from 'sonner';
+
+export default function RegistrarUsuario() {
+  const [formData, setFormData] = useState<Usuario>({
+    documento: '',
+    nombres: '',
+    apellidos: '',
+    telefono: '',
+    email: '',
+    rol: '',
+    empresaId: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [empresas, setEmpresas] = useState<Empresa[]>([]);
+  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      try {
+        const decoded = jwtDecode<{ rol?: string }>(token);
+        setIsSuperAdmin(decoded.rol === 'superadmin');
+      } catch {
+        // ignore decoding errors
+      }
+    }
+
+    const fetchEmpresas = async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/empresas`, {
+          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+        });
+        const data = await res.json();
+        if (Array.isArray(data)) setEmpresas(data);
+      } catch {
+        toast.error('Error al cargar empresas');
+      }
+    };
+
+    fetchEmpresas();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleRolSelect = (rol: string) => {
+    setFormData((prev) => ({ ...prev, rol, empresaId: rol === 'admin' || rol === 'empleado' ? prev.empresaId : '' }));
+  };
+
+  const handleEmpresaSelect = (empresaId: string) => {
+    setFormData((prev) => ({ ...prev, empresaId }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json();
+      if (!res.ok || !data?.id) {
+        throw new Error();
+      }
+      toast.success('Usuario registrado exitosamente');
+    } catch {
+      toast.error('Error al registrar usuario');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-[#fdfdfc] rounded-xl shadow-sm max-w-3xl mx-auto">
+      <h2 className="text-2xl font-semibold mb-4 text-black">Registrar Usuario</h2>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {(
+            [
+              ['documento', 'Documento'],
+              ['nombres', 'Nombres'],
+              ['apellidos', 'Apellidos'],
+              ['telefono', 'Teléfono'],
+              ['email', 'Correo'],
+            ] as [keyof Usuario, string][]
+          ).map(([name, label]) => (
+            <div key={name}>
+              <Label htmlFor={name} className="text-black">
+                {label}
+              </Label>
+              <Input
+                name={name}
+                value={formData[name]}
+                onChange={handleChange}
+                placeholder={label}
+                className="text-black placeholder-gray-400"
+              />
+            </div>
+          ))}
+
+          {/* Rol */}
+          <div>
+            <Label htmlFor="rol" className="text-black">Rol</Label>
+            <Select onValueChange={handleRolSelect} value={formData.rol}>
+              <SelectTrigger className="w-full text-black">
+                <SelectValue placeholder="Seleccionar rol" />
+              </SelectTrigger>
+              <SelectContent>
+                {(isSuperAdmin ? ['superadmin', 'admin', 'empleado'] : ['admin', 'empleado']).map((rol) => (
+                  <SelectItem key={rol} value={rol}>
+                    {rol}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Empresa (solo admin o empleado) */}
+          {(formData.rol === 'admin' || formData.rol === 'empleado') && (
+            <div>
+              <Label htmlFor="empresaId" className="text-black">Empresa</Label>
+              <Select onValueChange={handleEmpresaSelect} value={formData.empresaId}>
+                <SelectTrigger className="w-full text-black">
+                  <SelectValue placeholder="Seleccionar empresa" />
+                </SelectTrigger>
+                <SelectContent>
+                  {empresas.map((e) => (
+                    <SelectItem key={e.id} value={e.id}>
+                      {e.razonSocial}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+        <div className="text-right">
+          <Button type="submit" disabled={loading} className="bg-blue-700 hover:bg-blue-800 text-white rounded-xl">
+            {loading ? 'Registrando...' : 'Registrar'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -1,0 +1,5 @@
+import ConsultarUsuarios from './ConsultarUsuarios';
+
+export default function UsuariosPage() {
+  return <ConsultarUsuarios />;
+}

--- a/src/app/dashboard/usuarios/registrar/page.tsx
+++ b/src/app/dashboard/usuarios/registrar/page.tsx
@@ -1,0 +1,5 @@
+import RegistrarUsuario from '../RegistrarUsuario';
+
+export default function RegistrarUsuarioPage() {
+  return <RegistrarUsuario />;
+}

--- a/src/app/empresas/registrar/page.tsx
+++ b/src/app/empresas/registrar/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { Empresa } from '@/types';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { useAuthGuard } from '@/hooks/useAuthGuard';
@@ -9,10 +10,10 @@ export default function RegistrarEmpresaPage() {
   useAuthGuard();
   const router = useRouter();
 
-  const [form, setForm] = useState({
-    nombre: '',
+  const [form, setForm] = useState<Omit<Empresa, 'id'>>({
     nit: '',
-    email: '',
+    razonSocial: '',
+    direccion: '',
     telefono: '',
   });
 
@@ -23,15 +24,9 @@ export default function RegistrarEmpresaPage() {
   };
 
   const validarFormulario = () => {
-    const { nombre, nit, email, telefono } = form;
-    if (!nombre || !nit || !email || !telefono) {
+    const { nit, razonSocial, direccion, telefono } = form;
+    if (!nit || !razonSocial || !direccion || !telefono) {
       toast.error('Todos los campos son obligatorios.');
-      return false;
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      toast.error('El correo electrónico no es válido.');
       return false;
     }
 
@@ -71,16 +66,18 @@ export default function RegistrarEmpresaPage() {
       <h2 className="text-2xl font-semibold text-blue-800 mb-4">Registrar Empresa</h2>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        {['nombre', 'nit', 'email', 'telefono'].map((campo) => (
+        {(
+          ['nit', 'razonSocial', 'direccion', 'telefono'] as (keyof typeof form)[]
+        ).map((campo) => (
           <div key={campo}>
             <label className="block text-sm text-gray-700 mb-1 capitalize">
               {campo}
             </label>
             <input
               name={campo}
-              value={(form as any)[campo]}
+              value={form[campo as keyof typeof form]}
               onChange={handleChange}
-              type={campo === 'email' ? 'email' : 'text'}
+              type='text'
               className="w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring-1 focus:ring-blue-600"
               required
               disabled={loading}

--- a/src/components/usuarios/ModalEditarUsuario.tsx
+++ b/src/components/usuarios/ModalEditarUsuario.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import type { Usuario } from '@/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import UsuarioForm from './UsuarioForm';
+import { toast } from 'sonner';
+
+interface Props {
+  usuario: Usuario;
+  onClose: () => void;
+  onActualizado: () => void;
+}
+
+export default function ModalEditarUsuario({ usuario, onClose, onActualizado }: Props) {
+  const [formData, setFormData] = useState({ ...usuario });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleUpdate = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/usuarios/${usuario.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Usuario actualizado');
+      onActualizado();
+      onClose();
+    } catch {
+      toast.error('Error al actualizar usuario');
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="backdrop-blur-xl">
+        <DialogHeader>
+          <DialogTitle className="text-black">Editar Usuario</DialogTitle>
+        </DialogHeader>
+        <UsuarioForm formData={formData} onChange={handleChange} />
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={onClose}>Cancelar</Button>
+          <Button onClick={handleUpdate} className="bg-blue-600 text-white hover:bg-blue-700">Guardar</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/usuarios/UsuarioForm.tsx
+++ b/src/components/usuarios/UsuarioForm.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import type { Usuario } from '@/types';
+
+interface Props {
+  formData: Usuario;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function UsuarioForm({ formData, onChange }: Props) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {(
+        [
+          ['documento', 'Documento'],
+          ['nombres', 'Nombres'],
+          ['apellidos', 'Apellidos'],
+          ['telefono', 'Teléfono'],
+          ['email', 'Correo'],
+          ['rol', 'Rol'],
+        ] as [keyof Usuario, string][]
+      ).map(([name, label]) => (
+        <div key={name}>
+          <Label htmlFor={name} className="text-black">
+            {label}
+          </Label>
+          <Input
+            name={name}
+            id={name}
+            placeholder={label}
+            value={formData[name]}
+            onChange={onChange}
+            className="text-black placeholder:text-gray-400 rounded-xl"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+export interface Usuario {
+  id?: string;
+  documento: string;
+  nombres: string;
+  apellidos: string;
+  telefono: string;
+  email: string;
+  rol: string;
+  empresaId?: string;
+}
+
+export interface Empresa {
+  id: string;
+  nit: string;
+  razonSocial: string;
+  direccion: string;
+  telefono: string;
+}
+


### PR DESCRIPTION
## Summary
- implement `RegistrarUsuario` and `ConsultarUsuarios`
- add reusable `UsuarioForm` and `ModalEditarUsuario`
- update Dashboard layout to link to user pages
- wire up Next.js pages for user routes
- render nested user pages in dashboard layout
- fix rendering for company views when not on user routes
- **Fix user management and menu**
- fix lint errors
- fix sidebar effect dependencies and cleanup
- revise type definitions and form fields
- reset dashboard view when clicking logo

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6851e14753b483209b70a6141f64852c